### PR TITLE
fix a bug when playing games on pip boy

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -137,6 +137,21 @@ TCPRelay.prototype.listen = function listen (upstreamInfo, cb) {
       cb(copiedBuffer, telemetry)
     })
 
+    client.on('error', function (err) {
+      console.error(err)
+    })
+    
+    client.on('close', function (hadError) {
+      if (hadError) {
+        console.error('error on close')
+      }
+      fakeClient.close()
+    })
+
+    client.on('end', function () {
+      fakeClient.end()
+    })
+    
     fakeClient.on('close', function (hadError) {
       if (hadError) {
         console.error('error on close')


### PR DESCRIPTION
The pipboy seems to disconnect while playing games, this causes an EPIPE error.
This commit adds an error handler to client to make tracing easier and handles end and close on the socket.