### PR TITLE
require local pipboylib for example.js

### DIFF
--- a/example.js
+++ b/example.js
@@ -3,15 +3,15 @@ var hexy = require('hexy')
 var util = require('util')
 var _ = require('lodash')
 
-var pipboylib = require('pipboylib')
-var relay = require('pipboylib/lib/relay')
+var pipboylib = require('.')
+var relay = require('./lib/relay')
 
 var UDPRelay = relay.UDPRelay
 var TCPRelay = relay.TCPRelay
 
 var falloutClient = new pipboylib.DiscoveryClient()
 
-var parser = require('pipboylib/lib/parser')
+var parser = require('./lib/parser')
 
 var logPackets = false
 


### PR DESCRIPTION
Wanted to be able to run the example with my cloned version (without a global install of pipboylib itself, since I can't install pipboylib within pipboylib).

/cc @nelix 