### PR TITLE
Added preliminary findings of server-to-app communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In order for the utilities provided here to work, you'll need a running Fallout 
 As we figure out the spec we'll document what we can over in [docs](docs):
 
 * [App to Server Message Spec](docs/app-msg-spec.md)
+* [Server to App Message Spec](docs/server-msg-spec.md)
 
 ## TODO
 

--- a/docs/server-msg-spec.md
+++ b/docs/server-msg-spec.md
@@ -1,0 +1,59 @@
+# Server to app protocol
+
+### Basics
+
+All values follow the little-endian encoding, strings are suspected to be UTF-8 or Latin-1.
+
+The server listens on TCP port 27000 and immediately starts transmitting after a client connects. There is no specific handshake protocol. Thus far transmission always starts with two packets:
+
+1. JSON-Document concerning language and version of the game
+2. binary object tree containing all game-relevant data to display
+
+The app can send JSON messages to the server (see [App to Server Message Spec](app-msg-spec.md)), otherwise the server keeps sending packages to the client whenever data updates become available.
+
+### Basic structure
+
+The basical protocol seems to be composed of packages prefixed by length (32-bit value) and type (8-bit value). After this the data follows directly, which may be in the same TCP package but may be not. Known types thus far:
+
+- 0: ping/pong/keepalive
+- 1: JSON text
+- 3: binary object update
+
+## 0 Ping/Pong keepalive
+
+Whenever nothing specific happens, the server sends an empty (length = 0) package of type 0, which is copied by the app and sent back to the server.
+
+## 1 JSON text
+
+JSON text is just that. This comes up for example when the first connection is made.
+
+## 3 binary objects
+
+A binary object update package is basically a large collection of packages in the form of (type::int8, identifier::int32, content) where the content depends on the actual package type. The identifiers are arbitrary integers but in practice start from zero upwards. The identifier 0 (zero) denotes the root dictionary of the complete game data.
+
+The easiest way to parse the initial object update is to read in all objects one by one (generating a large table of value -> object data)and then start building the object graph at object 0 (root) resolving array/dictionary references along the way.
+
+After the initial update the game simply sends more object update packages, e.g. when the player moves, the object update package contains only two objects, the player's X and Y position. These are transmitted using the same identifiers as in the initial update. It is therefore necessary to track the link between object identifiers and game object graph to properly process the updates (e.g. a map position update may just be something like "float value 5764 = 1234.0, float value 5766 = 2345.0" on the wire).
+
+### object types
+
+| type | size (bytes) | meaning |
+|------|------|---------|
+| 0 | 1 | boolean value, indicating true (1) or false (0) |
+| 1 | 1 | signed byte value (no values exceeding 0x7f have been observed yet) |
+| 2 | 1 | unsigned byte value (no values exceeding 0x7f have been observed yet) |
+| 3 | 4 | signed 32-bit integer value |
+| 4 | 4 | unsigned 32-bit integer value |
+| 5 | 4 | 32-bit floating point value |
+| 6 | variable | zero-termined string (UTF-8?)
+| 7 | 2 + 4 * size | array of objects; first a 2-byte integer value follows to give the number of elements to follow. Then exactly that amount of object identifiers (4 byte each) follows. |
+| 8 | 2 + variable + 2| dictionary of objects; first a 2-byte integer value follows to give the number of key-value pairs. Then for each key-value pair first follows the identifier (4 byte) of the value object and then a zero-terminated key string. An additional two (zero?) bytes conclude the dictionary, their meaning has not been determined yet. |
+
+## object graph contents
+
+The object graph contains a variety of objects, both known to the player and yet unknown to the player (for example it seems to contain all locations already). For example to quickly look up the player's current special values, one can simply navigate through the object graph (here using python):
+
+	for stat in root["Special"]:
+		print "%s: %d" % (stat["Name"], stat["Value"])
+		
+This section probably needs a lot more expansion but the basic object graph is quite human-readable. For example root.Map.Local.Player.X denotes the local map player X position while Object.Inventory.[typeID].[arrayIndex].text is the name of an item.


### PR DESCRIPTION
Hi,

sparked interest by your blog article (nice work on the intercept infrastructure thus far), so I went into the dumps and tried to figure out the server-to-app protocol. While it still has some corners, it successfully decodes the complete object tree and gives information to your SPECIALs, stats, inventory, map, radio, ... basically everything also available in the Pip. This pull request includes documentation on the protocol as I found thus far (maybe someone recognizes something already implemented?). It is at least enough to grab most of the statistics and should also work to have an updating map.

As a proof of concept a simple, hacked-together python parser for the object graph (which can be fed by netcat) can be found at https://gist.github.com/TriPhoenix/01e74f0055b072b615a4
It basically waits for the first object tree update and dumps the complete tree as a JSON document (which can then be inspected further). Additionally it shows your SPECIALs as a PoC (which is just a simple root.Special.arrayIndex.Name/Value iteration):

```
% nc 192.168.2.109 27000 | python pip.py
{
    "Inventory": {
        "29": [
            {
                "FavIconType": 46,
...
            ]
        }
    ]
}

SPECIAL stats of TriPhoenix:
Strength: 4
Perception: 3
Endurance: 7
Charisma: 3
Intelligence: 4
Agility: 4
Luck: 6
```

After that initial dump the game basically just keeps updating objects in the graph; when you for example move or rotate, it simply updates the graph nodes for map player position or rotation with new values. As long as you saved the mapping while parsing the initial response, you can therefore easily grab updates to all data. I haven't encountered any packets that don't match this behaviour yet, however its not easy to properly track everything as the game sends quite a lot of updates all of the time :-)

Looking at the results I feel that sometimes the numbers look "odd" yet, for example the node Map.Local.Extents:
```
            "Extents": {
                "NEX": -2.228280315730175e-33,
                "NEY": 4.203895392974451e-45,
                "NWX": 7.030201665838976e+35,
                "NWY": 5.605193857299268e-45,
                "SWX": -1.7708112284338368e-37,
                "SWY": 4.590513639281668e-41
            },
```
however the world map extents (bearing the same float32 data type) look quite reasonable given the already known structure of set-map-marker app-to-server packets:
```
            "Extents": {
                "NEX": 114688.0,
                "NEY": 102400.0,
                "NWX": -135168.0,
                "NWY": 102400.0,
                "SWX": -135168.0,
                "SWY": -147456.0
            },
```

In any case hopefully this helps out in making a more proper decoder :-)