### PR TITLE
Remove 'buffertools' dependency + typo fix

### DIFF
--- a/lib/pipdb.js
+++ b/lib/pipdb.js
@@ -1,4 +1,3 @@
-require('buffertools').extend();
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 

--- a/lib/pipdecode.js
+++ b/lib/pipdecode.js
@@ -1,4 +1,3 @@
-require('buffertools').extend();
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
@@ -28,7 +27,7 @@ module.exports = function() {
   var emitter = new PipDecode();
 
   emitter.on('data', function(data) {
-    this.buffer = this.buffer.concat(data);
+    this.buffer = Buffer.concat([this.buffer, data]);
 
     if(!this.expectedSize) {
       this.expectedSize = this.buffer.readUInt32LE(0) + 5;
@@ -56,7 +55,7 @@ module.exports = function() {
           this.emit('localmap_update', data);
           break;
         case Channels.CommandResponse:
-          this.emit('command_response', JSOn.parse(data.toString()));
+          this.emit('command_response', JSON.parse(data.toString()));
           break;
       }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "https://github.com/rgbkrk/pipboylib.git"
   },
   "dependencies": {
-    "buffertools": "^2.1.3",
     "concentrate": "0.2.3",
     "dissolve": "0.3.3",
     "lodash": "3.10.1"


### PR DESCRIPTION
I was using `buffertools` for a rather trivial thing and it turns out node has this built-in since a while ago so the dependency can easily be removed.

also `JSOn` typo fix 