### PR TITLE
Match name of the export from connection/index.js

### DIFF
--- a/src/connection/createSocket.js
+++ b/src/connection/createSocket.js
@@ -6,7 +6,7 @@ import {
   FALLOUT_TCP_PORT
 } from '../constants';
 
-export default function createConnection(host) {
+export default function createSocket(host) {
   const socket = new Socket()
   socket.connect(FALLOUT_TCP_PORT, host)
   return socket


### PR DESCRIPTION
The export is `createSocket` to those importing from `pipboylib.connection`. Make it match the name of the function in source.