### PR TITLE
lowercase commands

### DIFF
--- a/src/encoding/generateCommandBuffer.js
+++ b/src/encoding/generateCommandBuffer.js
@@ -20,9 +20,9 @@ export default function generateCommandBuffer(type, ...args) {
     args = args[1]
   }
 
-  if (!Commands.hasOwnProperty(type)) {
+  if (!commands.hasOwnProperty(type)) {
     throw `Unknown command type ${type}!`
   }
 
-  return encodePacket(Commands[type], args)
+  return encodePacket(commands[type], args)
 }


### PR DESCRIPTION
`Commands` was meant to be `commands` here.