### PR TITLE
run the build on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "The companion pipboy library to Fallout 4",
   "main": "lib/index.js",
   "scripts": {
+    "prepublish": "npm run compile",
     "compile": "rm -rf lib && babel src -q --out-dir lib",
-    "postinstall": "npm run compile",
     "pretest": "npm run compile",
     "test": "babel-tape-runner test/*.js | faucet",
     "example": "babel-node example.js"


### PR DESCRIPTION
For users of the library, this makes it so they don't have to build
our released copy on install straight from npm.

For developers of the library, `npm install` on a dev copy will run
prepublish (noted `npm` behavior).